### PR TITLE
Handling the `jinja2.exceptions.UndefinedError: 'v' is undefined` exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ pip install -e .
 ```
 ## Usage
 
-rmldoc offers the following options:
+**rmldoc** offers the following options:
+
 ```bash
 usage: rmldoc [-h] -i INPUT_MAPPING_PATH [-o OUTPUT_PATH]
 
@@ -47,18 +48,28 @@ optional arguments:
 ```
 
 
-To generate documentation for your mappings, use the following command:
+To generate documentation for your mappings, use the following command, where you would replace `path/to/rml/mappings.rml` with the path to your RML mapping file and `path/to/output/directory/mappings.md` with the file where you want the documentation to be generated:
 
 ```bash
 rmldoc -i path/to/rml/mappings.rml - o path/to/output/directory/mappings.md
 ```
 
-Replace `path/to/rml/mappings.rml` with the path to your RML mapping file and `path/to/output/directory/mappings.md` with the file where you want the documentation to be generated.
+To automate documentation generation using GNU's [make](https://www.gnu.org/software/make/manual/make.html), a typical implementation would involve creating a *makefile* with the following structure:
+```makefile
+doc-rml:  ## Generate documentation for RML
+	@echo -e "\033[35m > Generate documentation for RML \033[0m - requires RMLdoc: see https://github.com/oeg-upm/rmldoc"
+	@find mapping/ -type f -name *.ttl \
+		-printf "\n%f\n" \
+		-exec rmldoc -i {} -o {}.md \;
+	@echo -e "\033[35m > Done  \033[0m"
+```
 
 ## Example
+
 The following [link](https://github.com/oeg-upm/rmldoc/blob/main/example/example.md) shows the result produced by `RMLdoc` from the following [mapping file](https://github.com/oeg-upm/rmldoc/blob/main/example/example_input.ttl).
 
 ## RMLdoc specification
+
 The [RMLdoc specification](https://github.com/oeg-upm/rmldoc/blob/main/spec/specification.md) describes the main metadata expected in a RML mapping file. Have a look to create eye-catching documentations!
 
 ## Contributing
@@ -66,6 +77,7 @@ The [RMLdoc specification](https://github.com/oeg-upm/rmldoc/blob/main/spec/spec
 Contributions to `RMLdoc` are welcome! If you encounter any issues or have suggestions for improvements, please open an issue or submit a pull request on GitHub.
 
 ## Authors
+
 * [Jhon Toledo](https://github.com/jatoledo) ([ja.toledo@upm.es](mailto:ja.toledo@upm.es))
 * [Ana Iglesias-Molina](https://github.com/anaigmo)
 * [David Chaves-Fraga](https://github.com/dachafra)

--- a/src/rmldoc/Templates/rmd.md
+++ b/src/rmldoc/Templates/rmd.md
@@ -35,17 +35,9 @@
 {%- endfor -%}
 {% endblock %}
 {%- block license %}
-{% if version|length > 1 and v['license'] is defined  %}
- {% for v in version -%}
-  {% if 'https://creativecommons.org/licenses/by/4.0' in v['license'] or v['license']=='None' %}
-[![http://insertlicenseURIhere.org](https://img.shields.io/badge/License-Creative%20Commons%20Attribution%204.0%20International%20(CC%20BY%204.0)-blue.svg)](https://creativecommons.org/licenses/by/4.0/)
-  {% else %}
-{{ v['license'] }}
- {% endif %}
-{%- endfor -%}
-{% else %}
-[![http://insertlicenseURIhere.org](https://img.shields.io/badge/License-Creative%20Commons%20Attribution%204.0%20International%20(CC%20BY%204.0)-blue.svg)](https://creativecommons.org/licenses/by/4.0/)
-{% endif %}
+{% for v in version -%}
+* {% if 'https://creativecommons.org/licenses/by/4.0' in v['license'] or v['license']=='None' %}[![http://insertlicenseURIhere.org](https://img.shields.io/badge/License-Creative%20Commons%20Attribution%204.0%20International%20(CC%20BY%204.0)-blue.svg)](https://creativecommons.org/licenses/by/4.0/){% else %}{{ v['license'] }}{% endif %} (v{{ v['version']}})
+{%- endfor %}
 {% endblock %}
 {%- block description %}
 {% for v in version -%}

--- a/src/rmldoc/__main__.py
+++ b/src/rmldoc/__main__.py
@@ -151,11 +151,16 @@ def workflow(rdf_mapping_path, output_path):
     spo_diagram = environment.get_template("diagram.md")
     join_diagram = environment.get_template("function.md")
     named_graph_template = environment.get_template("named_graph.md")
+
     # Version
     rml_version = g.query(dataset_version)
-
-    rml_version = [{"version": str(vr.version), "license": str(vr.license), "description": str(vr.description),
-                    "title": str(vr.title), "dateCreated": str(vr.dateCreated)} for vr in rml_version]
+    rml_version = [{"version": str(vr.version),
+                    "license": str(vr.license),
+                    "description": str(vr.description),
+                    "title": str(vr.title),
+                    "dateCreated": str(vr.dateCreated)}
+                   for vr in rml_version]
+    log.debug("rml_version = %s", rml_version)
 
     # Prefix
     # rmd_prefixes = g.namespaces()
@@ -221,7 +226,8 @@ def workflow(rdf_mapping_path, output_path):
     # parse the content
     # content = template.render(authors=rmd_authors, prefixes=rmd_prefixes, mapping_content=mapping_content)
 
-    content = template.render(version=rml_version, mapping_file=get_file_name(rdf_mapping_path),
+    content = template.render(version=rml_version,
+                              mapping_file=get_file_name(rdf_mapping_path),
                               authors=rmd_authors,
                               prefixes=rmd_prefixes,
                               mapping_content=mapping_content)
@@ -249,11 +255,12 @@ def workflow_with_yatter(rdf_mapping_path, output_path):
     spo_diagram = environment.get_template("diagram.md")
     join_diagram = environment.get_template("function.md")
     named_graph_template = environment.get_template("named_graph.md")
+
     # Version
     rml_version = g.query(dataset_version)
-
     rml_version = [{"version": str(vr.version), "license": str(vr.license), "description": str(vr.description),
                     "title": str(vr.title), "dateCreated": str(vr.dateCreated)} for vr in rml_version]
+    log.debug("rml_version = %s", rml_version)
 
     # Prefix
     # rmd_prefixes = g.namespaces()

--- a/src/rmldoc/queries.py
+++ b/src/rmldoc/queries.py
@@ -27,7 +27,7 @@ PREFIX void: <http://rdfs.org/ns/void#>
 PREFIX dc: <http://purl.org/dc/terms/>
 PREFIX dcat: <http://www.w3.org/ns/dcat#> 
 
-SELECT ?version ?license ?description ?title ?dateCreated
+SELECT DISTINCT ?version ?license ?description ?title ?dateCreated
 WHERE {
  VALUES (?map_class) {(schema:Dataset)(void:Dataset)(dcat:Dataset)}.
     ?triplesMap a ?map_class.


### PR DESCRIPTION
Minor template adjustments to match RML rules with metadata such as:

```
map:rules_000
	rdf:type schema:Dataset;
	schema:contributor map:person_000 ;
	schema:contributor map:person_001 ;
	void:exampleResource <https://github.com/Orange-OpenSource/graphameleon-ds> ;
	schema:version "0.1.0";
	schema:title "Graphameleon - macro";
	schema:dateCreated "01-10-2023";
	schema:description "RML mapping for data collection using Graphameleon in macro mode.";
	schema:license <https://github.com/Orange-OpenSource/graphameleon/blob/main/LICENSE.txt> ;
.
```

or (same as above without the schema:license triple):
```
map:rules_000
	rdf:type schema:Dataset;
	schema:contributor map:person_000 ;
	schema:contributor map:person_001 ;
	void:exampleResource <https://github.com/Orange-OpenSource/graphameleon-ds> ;
	schema:version "0.1.0";
	schema:title "Graphameleon - macro";
	schema:dateCreated "01-10-2023";
	schema:description "RML mapping for data collection using Graphameleon in macro mode.";
.
```
